### PR TITLE
Fix for removing the last image & video asset in an ad group, missing values

### DIFF
--- a/ads_service_api.py
+++ b/ads_service_api.py
@@ -502,8 +502,6 @@ class AdService():
 
         if add_or_remove == 'ADD':
             self._append_asset_operation(asset_operation, ad_asset)
-        else:
-            self._remove_asset_operation(asset_operation, ad_asset)
 
         field_mask = None
         prev_field_mask = copy.deepcopy(
@@ -514,6 +512,8 @@ class AdService():
         else:
             field_mask = protobuf_helpers.field_mask(None,
                                                new_list_of_asset.update._pb)
+        if add_or_remove == 'REMOVE':
+            self._remove_asset_operation(asset_operation, ad_asset)
 
         new_list_of_asset.update.resource_name = resource_name
         self._google_ads_client.copy_from(new_list_of_asset.update_mask, field_mask)   

--- a/sheets_api.py
+++ b/sheets_api.py
@@ -69,6 +69,7 @@ class SheetsService():
         range=field_range,
         valueInputOption='RAW',
         body=body).execute()
+    return values
 
   def update_sheet_columns(self, field_range, values):
     """Writes data into sheet.


### PR DESCRIPTION
Fixes for:
1) If the advertisers modifies the minimum requirements for image and video assets in ad group to 0, the script failed to remove the last assets with error: Unable to delete: Cannot use empty field mask in update operation.

2) In the last pull, forgot to include the change in the sheets_api.pyto be able to add checkboxes in time managed sheet